### PR TITLE
Fish taxonomy IDs

### DIFF
--- a/src/test/scala/pick16SCandidates.scala
+++ b/src/test/scala/pick16SCandidates.scala
@@ -36,7 +36,10 @@ case object pick16SCandidates extends FilterData(
   val unclassifiedBacteriaID = "2323"
 
   val fishTaxaIDs: Set[String] =
-    Set("fill", "this", "with", "something")
+    Set(
+      "6447", // Mollusca
+      "7776"  // Gnathostomata
+    )
 
   /* These are NCBI taxonomy IDs corresponding to taxa which are at best uniformative. The `String` value is the name of the corresponding taxon, for documentation purposes. */
   val uninformativeTaxIDsMap = Map(


### PR DESCRIPTION
should be added [here](https://github.com/era7bio/db.peces16s/blob/b59c902619f2585f68cb7fb1634b1f5c8d4aa046/src/test/scala/pick16SCandidates.scala#L38-L39).